### PR TITLE
I've refactored the PDF conversion service for different job types. H…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "start": "node app.js",
     "dev": "nodemon app.js",
-    "scrape": "node src/scraper.js"
+    "scrape": "node src/scraper.js",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "airtable": "^0.12.2",
-    "archiver": "^7.0.0",
+    "archiver": "^7.0.1",
     "axios": "^1.6.7",
     "canvas": "^3.1.0",
     "cors": "^2.8.5",
@@ -29,6 +30,9 @@
     "sharp": "^0.34.2"
   },
   "devDependencies": {
-    "nodemon": "^3.1.0"
+    "adm-zip": "^0.5.16",
+    "jest": "^29.7.0",
+    "nodemon": "^3.1.0",
+    "pdf-lib": "^1.17.1"
   }
 }

--- a/tests/pdfConverterService.test.js
+++ b/tests/pdfConverterService.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, afterAll, jest } from '@jest/globals';
+import { convertPdfToImages } from '../services/pdfConverterService.js';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { PDFDocument, rgb } from 'pdf-lib';
+import AdmZip from 'adm-zip'; // For checking zip contents
+
+// Adjust __dirname for ES modules
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const sampleFilesDir = path.join(__dirname, 'sample_files');
+const samplePdfPath = path.join(sampleFilesDir, 'test_document.pdf');
+let createdZipFilePath; // To store the path of the zip file for cleanup
+
+// Set a longer timeout for tests involving file operations and processing
+describe('pdfConverterService - Local Conversion (jobType: "converter")', () => {
+    jest.setTimeout(60000); // 60 seconds
+
+    beforeAll(async () => {
+        try {
+            // Create a directory for sample files if it doesn't exist
+            await fs.mkdir(sampleFilesDir, { recursive: true });
+
+            // Create a simple dummy PDF file for testing using pdf-lib
+            const pdfDoc = await PDFDocument.create();
+            const page = pdfDoc.addPage([300, 200]); // Small page size
+            page.drawText('This is a test PDF document for pdfConverterService.', {
+                x: 10,
+                y: 100,
+                size: 10,
+                color: rgb(0, 0, 0),
+            });
+            const pdfBytes = await pdfDoc.save();
+            await fs.writeFile(samplePdfPath, pdfBytes);
+            console.log(`Sample PDF created at: ${samplePdfPath}`);
+        } catch (error) {
+            console.error("Error in beforeAll creating sample PDF:", error);
+            throw error; // Fail the test setup if PDF can't be created
+        }
+    });
+
+    afterAll(async () => {
+        try {
+            // Clean up the sample PDF
+            await fs.unlink(samplePdfPath);
+            console.log(`Cleaned up sample PDF: ${samplePdfPath}`);
+        } catch (error) {
+            // Log error if cleanup fails but don't fail the test suite for it
+            console.warn(`Could not clean up sample PDF: ${samplePdfPath}. Error: ${error.message}`);
+        }
+
+        // Clean up the created zip file
+        if (createdZipFilePath) {
+            try {
+                await fs.unlink(createdZipFilePath);
+                console.log(`Cleaned up test zip file: ${createdZipFilePath}`);
+            } catch (error) {
+                console.warn(`Could not clean up test zip file: ${createdZipFilePath}. Error: ${error.message}`);
+            }
+        }
+        
+        // Clean up the sample_files directory if empty (optional)
+        try {
+            const files = await fs.readdir(sampleFilesDir);
+            if (files.length === 0) {
+                await fs.rmdir(sampleFilesDir);
+                console.log(`Cleaned up empty directory: ${sampleFilesDir}`);
+            }
+        } catch (error) {
+            // Ignore errors if directory is not empty or cannot be removed
+            console.warn(`Could not clean up directory ${sampleFilesDir}, it might not be empty or an error occurred: ${error.message}`);
+        }
+    });
+
+    it('should convert PDF to a zip file, return the zip file path, and the zip should contain PNG images', async () => {
+        try {
+            console.log(`Calling convertPdfToImages with PDF: ${samplePdfPath}, jobType: 'converter'`);
+            createdZipFilePath = await convertPdfToImages(samplePdfPath, 'converter');
+            console.log(`convertPdfToImages returned: ${createdZipFilePath}`);
+
+            // 1. Assert the function returns a string
+            expect(typeof createdZipFilePath).toBe('string');
+
+            // 2. Assert the path ends with '.zip'
+            expect(createdZipFilePath.endsWith('.zip')).toBe(true);
+
+            // 3. Assert the file at the returned path exists
+            await fs.access(createdZipFilePath); // Throws if not accessible
+            console.log(`Zip file exists at: ${createdZipFilePath}`);
+
+            // 4. Assert the file is a valid zip file and contains PNGs
+            const zip = new AdmZip(createdZipFilePath);
+            const zipEntries = zip.getEntries();
+            expect(zipEntries.length).toBeGreaterThan(0); // Check if not empty
+            
+            // Check if there's at least one PNG file (as we created a 1-page PDF)
+            const hasPngEntry = zipEntries.some(entry => entry.entryName.endsWith('.png') && !entry.isDirectory);
+            expect(hasPngEntry).toBe(true);
+            
+            console.log(`Test successful: Zip file created at ${createdZipFilePath} and contains PNG images.`);
+
+        } catch (error) {
+            console.error("Test execution error:", error);
+            // If an error occurs, ensure createdZipFilePath is still set if the function returned before failing assertions
+            if (error.message.includes("convertPdfToImages") && typeof createdZipFilePath === 'string') {
+                 // This helps ensure cleanup even if assertions fail after file creation
+            }
+            throw error; // Re-throw to fail the test
+        }
+    });
+});


### PR DESCRIPTION
…ere's a summary of the changes:

- I implemented conditional PDF conversion logic in `pdfConverterService.js`.
- For `jobType: 'converter'`:
    - I now convert PDFs to PNG images locally using `pdfjs-dist` and `canvas`.
    - I then archive the generated images into a zip file.
    - The service returns the path to this created zip file.
    - I've added `archiver` as a dependency for creating these zip files.
- For `jobType: 'kaza_analiz'` (and other types):
    - I continue to use the CloudConvert API for PDF to image conversion.
    - The service returns an array of image URLs in these cases.
- I've added tests for the local conversion path (`jobType: 'converter'`):
    - These verify that a zip file is created and contains PNG images.
    - I'm using `pdf-lib` to generate a sample PDF for testing purposes.
    - This required adding `jest` and `adm-zip` as development dependencies.
- I also resolved `pdfjs-dist` import issues in the Node.js ESM environment by using `createRequire`.