### PR TITLE
Refactor: Remove unused dependencies and optimize scraping

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "airtable": "^0.12.2",
     "archiver": "^7.0.1",
     "axios": "^1.6.7",
-    "canvas": "^3.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
@@ -21,18 +20,11 @@
     "multer": "^2.0.0",
     "node-cache": "^5.1.2",
     "openai": "^4.30.0",
-    "pdf-poppler": "^0.2.1",
-    "pdf2pic": "^3.1.4",
-    "pdfjs-dist": "^2.16.105",
     "playwright": "^1.42.1",
-    "playwright-extra": "^4.3.6",
-    "puppeteer-extra-plugin-stealth": "^2.11.2",
-    "sharp": "^0.34.2"
+    "playwright-extra": "^4.3.6"
   },
   "devDependencies": {
-    "adm-zip": "^0.5.16",
     "jest": "^29.7.0",
-    "nodemon": "^3.1.0",
-    "pdf-lib": "^1.17.1"
+    "nodemon": "^3.1.0"
   }
 }

--- a/src/scraper.js
+++ b/src/scraper.js
@@ -1,6 +1,5 @@
-import { chromium } from 'playwright';
-import playwright from 'playwright-extra';
-import stealth from 'puppeteer-extra-plugin-stealth';
+import { chromium } from 'playwright-extra';
+import stealth from 'playwright-extra/plugins/stealth/index.js';
 import NodeCache from 'node-cache';
 import config from '../config.js'; // Import config
 
@@ -8,7 +7,7 @@ import config from '../config.js'; // Import config
 const cache = new NodeCache({ stdTTL: config.scraper.cacheTTL });
 
 // Add stealth plugin
-playwright.chromium.use(stealth());
+chromium.use(stealth());
 
 /**
  * ScraperService class provides methods to scrape web pages using Playwright.
@@ -39,7 +38,7 @@ class ScraperService {
     async initialize() {
         if (!this.browser) {
             console.log('ScraperService: Initializing new browser instance...');
-            this.browser = await playwright.chromium.launch({
+            this.browser = await chromium.launch({
                 headless: true,
                 args: config.scraper.launchArgs // Launch args from config
             });


### PR DESCRIPTION
This commit removes several unused dependencies and refactors the web scraping service.

Removed dependencies:
- pdf-poppler
- pdf2pic
- pdfjs-dist
- pdf-lib (devDependency)
- puppeteer-extra-plugin-stealth
- adm-zip (devDependency)
- sharp
- canvas

These libraries were identified as unused after a codebase review. Their removal reduces the project's footprint and potential security vulnerabilities.

Scraper Optimization:
- Modified `src/scraper.js` to correctly use the stealth plugin from `playwright-extra` instead of attempting to use a Puppeteer-specific plugin.